### PR TITLE
Use `Any` type for untyped channels

### DIFF
--- a/src/Control/Concurrent/UntypedChannel.hs
+++ b/src/Control/Concurrent/UntypedChannel.hs
@@ -5,8 +5,9 @@ module Control.Concurrent.UntypedChannel where
 import Unsafe.Coerce
 import Control.Concurrent.MVar (MVar, putMVar, takeMVar, newEmptyMVar)
 import qualified Control.Concurrent as Conc
+import GHC.Exts (Any)
 
-data Channel = Chan { sendOn :: MVar Integer, recvOn :: MVar Integer }
+data Channel = Chan { sendOn :: MVar Any, recvOn :: MVar Any }
 data CPair = CPair Channel Channel
 
 newChan :: IO CPair


### PR DESCRIPTION
Using [`Any`](https://hackage.haskell.org/package/base-4.18.0.0/docs/GHC-Exts.html#t:Any) for the channel payload is a better choice:

> The type constructor [`Any`](https://hackage.haskell.org/package/base-4.18.0.0/docs/GHC-Exts.html#t:Any) is type to which you can unsafely coerce any lifted type, and back. More concretely, for a lifted type `t` and value `x :: t`, `unsafeCoerce (unsafeCoerce x :: Any) :: t` is equivalent to `x`.
